### PR TITLE
fix: use -R instead of -r to preserve symlinks

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -31,7 +31,7 @@ function install() {
   mkdir -p ./bin
   ln -s ../language_server.sh ./bin/elixir-ls
   ln -s ../debug_adapter.sh ./bin/elixir-ls-debugger
-  cp -fpr * "${install_path}"
+  cp -fpR * "${install_path}"
 
   popd >/dev/null
   popd >/dev/null


### PR DESCRIPTION
Changed `cp -fpr` to `cp -fpR` in bin/install. The uppercase `-R` flag is required to properly preserve symlinks during recursive copy operations.

fixes #3